### PR TITLE
chore(github): add additional triggers to audit-check

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -3,8 +3,14 @@
 
 name: Security audit
 on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
allow running audit-check manually and run on changes to Cargo.toml and
Cargo.lock
