### PR TITLE
fix: drop `colors` keyword, because there can only be 5 keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MIT"
 description = "A colorful commandline calendar with ical support. Similar to `cal`, but with features."
 repository = "https://github.com/b1rger/carl"
-keywords = ["calendar", "ical", "cli", "date", "cal", "colors"]
+keywords = ["calendar", "ical", "cli", "date", "cal"]
 categories = ["command-line-utilities", "date-and-time"]
 
 [dependencies]


### PR DESCRIPTION
crates.io: expected at most 5 keywords per crate
