### PR TITLE
Switch to icalendar and use rrule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "chrono",
  "clap",
  "ical",
+ "icalendar",
  "serde",
  "toml",
  "xdg",
@@ -117,7 +118,9 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.48.0",
 ]
 
@@ -180,6 +183,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +240,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "icalendar"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4ffbcf3325ae94554c5259ce0b8907d37133c066cb3d424a2fa96aa1f10088"
+dependencies = [
+ "chrono",
+ "iso8601",
+ "nom",
+ "uuid",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +259,15 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -262,6 +299,22 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-traits"
@@ -407,6 +460,22 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "getrandom",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +101,7 @@ dependencies = [
  "chrono",
  "clap",
  "icalendar",
+ "rrule",
  "serde",
  "toml",
  "xdg",
@@ -121,6 +131,28 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -270,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +360,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +422,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rrule"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "615777991e415d96aa97f6e45e809111911497c029e5d0df7f6d751d218d28e8"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "lazy_static",
+ "log",
+ "regex",
+ "thiserror",
 ]
 
 [[package]]
@@ -369,6 +512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +532,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "ical",
  "icalendar",
  "serde",
  "toml",
@@ -228,15 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "ical"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26393c372d4c4d51616084afe36c0b44e4467febaa6f91f11f789094b4863bf9"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -393,26 +383,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 xdg = "2.5.2"
 anstyle = "1.0.4"
 icalendar = "0.16"
+rrule = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ clap = { version = "4.4.11", features = ["derive", "cargo"] }
 toml = "0.8.*"
 serde = { version = "1.0", features = ["derive"] }
 xdg = "2.5.2"
-ical = "0.9.*"
 anstyle = "1.0.4"
-icalendar = "*"
+icalendar = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 xdg = "2.5.2"
 ical = "0.9.*"
 anstyle = "1.0.4"
+icalendar = "*"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-use crate::utils::ChronoDate;
 use anyhow::{anyhow, Result};
 use chrono::prelude::*;
 use clap::{crate_authors, crate_name, crate_version, Parser};
@@ -57,8 +56,8 @@ impl Default for Cli {
 }
 
 impl Cli {
-    pub fn validate_date(&self) -> Result<ChronoDate> {
-        let mut today: ChronoDate = Local::now().date_naive();
+    pub fn validate_date(&self) -> Result<chrono::NaiveDate> {
+        let mut today: chrono::NaiveDate = Local::now().date_naive();
         let mut year: i32 = today.year();
         let mut month: u32 = today.month();
         let mut day: u32 = today.day();
@@ -147,13 +146,13 @@ mod tests {
 
     #[test]
     fn test_validate_date_defaults_to_now() {
-        let today: ChronoDate = Local::now().date_naive();
+        let today: chrono::NaiveDate = Local::now().date_naive();
         let o: Cli = Cli::default();
         assert_eq!(today, o.validate_date().unwrap());
     }
     #[test]
     fn test_validate_date_default_to_now_with_custom_year() {
-        let today: ChronoDate = Local::now().date_naive().with_year(2007).unwrap();
+        let today: chrono::NaiveDate = Local::now().date_naive().with_year(2007).unwrap();
         let o: Cli = Cli {
             date: vec![String::from("2007")],
             ..Default::default()
@@ -162,7 +161,7 @@ mod tests {
     }
     #[test]
     fn test_validate_date_defaults_to_now_with_custom_year_and_month() {
-        let today: ChronoDate = Local::now()
+        let today: chrono::NaiveDate = Local::now()
             .date_naive()
             .with_year(2007)
             .unwrap()
@@ -176,7 +175,7 @@ mod tests {
     }
     #[test]
     fn test_validate_date_defaults_to_now_with_custom_year_and_month_and_day() {
-        let today: ChronoDate = Local::now()
+        let today: chrono::NaiveDate = Local::now()
             .date_naive()
             .with_year(2007)
             .unwrap()
@@ -192,7 +191,7 @@ mod tests {
     }
     #[test]
     fn test_validate_date_defaults_to_now_with_ambiguous_arguments() {
-        let today: ChronoDate = Local::now().date_naive();
+        let today: chrono::NaiveDate = Local::now().date_naive();
         let o: Cli = Cli {
             date: vec![
                 String::from("2007"),
@@ -266,7 +265,7 @@ mod tests {
     }
     #[test]
     fn test_validate_date_errors_with_non_existent_date() {
-        let today: ChronoDate = Local::now().date_naive();
+        let today: chrono::NaiveDate = Local::now().date_naive();
         let o: Cli = Cli {
             date: vec![String::from("2007"), String::from("2"), String::from("30")],
             ..Default::default()

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,14 +6,13 @@ use crate::cli::Cli;
 use crate::config::{Config, Theme};
 use crate::config::{Style, StyleType};
 use crate::events::Event;
-use crate::utils::ChronoDate;
 use anyhow::Result;
 use chrono::prelude::*;
 use clap::Parser;
 
 // A struct storing the combined settings of config file, theme, options, ...
 pub struct Context {
-    pub usersetdate: ChronoDate,
+    pub usersetdate: chrono::NaiveDate,
     pub opts: Cli,
     pub config: Config,
     pub eventstuple: Vec<(Event, Style)>,
@@ -37,7 +36,7 @@ impl Context {
             StyleType::Light
         };
 
-        let usersetdate: ChronoDate = match opts.validate_date() {
+        let usersetdate: chrono::NaiveDate = match opts.validate_date() {
             Ok(x) => x,
             Err(x) => return Err(x),
         };

--- a/src/events/ics.rs
+++ b/src/events/ics.rs
@@ -51,7 +51,6 @@ impl TryFrom<&IcalendarEvent> for Event {
     fn try_from(event: &IcalendarEvent) -> Result<Self, Self::Error> {
         let mut start: Option<EventDateTime> = None;
         let mut end: Option<EventDateTime> = None;
-        let mut summary: String = String::new();
         let mut frequency: EventFrequency = EventFrequency::None;
         for (name, value) in event.properties() {
             match name.as_str() {
@@ -60,9 +59,6 @@ impl TryFrom<&IcalendarEvent> for Event {
                 }
                 "DTEND" => {
                     end = EventDateTime::try_from(value).ok();
-                }
-                "SUMMARY" => {
-                    summary = value.value().to_string();
                 }
                 "RRULE" => {
                     frequency = EventFrequency::from(value);
@@ -75,7 +71,7 @@ impl TryFrom<&IcalendarEvent> for Event {
                 start: x,
                 end,
                 frequency,
-                summary,
+                summary: event.get_summary().unwrap_or_default().to_string(),
             })
         } else {
             Err("Could not parse ical event.")

--- a/src/events/ics.rs
+++ b/src/events/ics.rs
@@ -37,9 +37,10 @@ impl TryFrom<&icalendar::Property> for EventDateTime {
         } else if let Ok(naive_datetime) =
             NaiveDateTime::parse_from_str(property.value(), "%Y%m%dT%H%M%S")
         {
-            if let Some(x) = Local.from_local_datetime(&naive_datetime).single() {
-                return Ok(EventDateTime::DateTime(x));
-            }
+            return Ok(EventDateTime::DateTime {
+                date_time: naive_datetime,
+                offset: None,
+            });
         }
         Err("Could not parse ical property.")
     }
@@ -128,7 +129,6 @@ impl ReadFromIcsFile for Events {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Local, TimeZone};
 
     #[test]
     fn test_property_to_frequency_yearly() {
@@ -162,11 +162,14 @@ mod tests {
     }
     #[test]
     fn test_property_to_eventdatetime_2() {
-        let property = icalendar::Property::new("DTSTART", "19700101T010130");
-        let date = Local.timestamp_opt(90, 0).unwrap();
+        let property = icalendar::Property::new("DTSTART", "19700101T000000");
+        let date_time = NaiveDateTime::default();
         assert_eq!(
             EventDateTime::try_from(&property),
-            Ok(EventDateTime::DateTime(date))
+            Ok(EventDateTime::DateTime {
+                date_time,
+                offset: None
+            })
         );
     }
     #[test]

--- a/src/events/ics.rs
+++ b/src/events/ics.rs
@@ -57,9 +57,9 @@ impl TryFrom<&IcalendarEvent> for Event {
         }
         if let Some(x) = event.get_start() {
             let start = x.into();
-            let end: Option<EventDateTime> = match event.get_end() {
-                Some(y) => Some(y.into()),
-                _ => None,
+            let end: EventDateTime = match event.get_end() {
+                Some(y) => y.into(),
+                _ => start,
             };
             Ok(Event {
                 start,

--- a/src/events/ics.rs
+++ b/src/events/ics.rs
@@ -136,115 +136,59 @@ mod tests {
 
     #[test]
     fn test_property_to_frequency_yearly() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("RRULE"),
-            params: None,
-            value: Some(String::from("FREQ=YEARLY")),
-        };
-        assert_eq!(EventFrequency::from(property), EventFrequency::Yearly);
+        let property = icalendar::Property::new("RRULE", "FREQ=YEARLY");
+        assert_eq!(EventFrequency::from(&property), EventFrequency::Yearly);
     }
     #[test]
     fn test_property_to_frequency_monthly() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("RRULE"),
-            params: None,
-            value: Some(String::from("FREQ=MONTHLY")),
-        };
-        assert_eq!(EventFrequency::from(property), EventFrequency::Monthly);
+        let property = icalendar::Property::new("RRULE", "FREQ=MONTHLY");
+        assert_eq!(EventFrequency::from(&property), EventFrequency::Monthly);
     }
     #[test]
     fn test_property_to_frequency_weekly() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("RRULE"),
-            params: None,
-            value: Some(String::from("FREQ=WEEKLY")),
-        };
-        assert_eq!(EventFrequency::from(property), EventFrequency::Weekly);
+        let property = icalendar::Property::new("RRULE", "FREQ=WEEKLY");
+        assert_eq!(EventFrequency::from(&property), EventFrequency::Weekly);
     }
     #[test]
     fn test_property_to_frequency_daily() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("RRULE"),
-            params: None,
-            value: Some(String::from("FREQ=DAILY")),
-        };
-        assert_eq!(EventFrequency::from(property), EventFrequency::Daily);
+        let property = icalendar::Property::new("RRULE", "FREQ=DAILY");
+        assert_eq!(EventFrequency::from(&property), EventFrequency::Daily);
     }
     #[test]
     fn test_property_to_eventdatetime_1() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("DTSTART"),
-            params: Some(vec![(String::from("VALUE"), vec![String::from("DATE")])]),
-            value: Some(String::from("19700101")),
-        };
+        let mut property = icalendar::Property::new("DTSTART", "19700101");
+        property.add_parameter("VALUE", "DATE");
         let date = NaiveDate::default();
         assert_eq!(
-            EventDateTime::try_from(property),
+            EventDateTime::try_from(&property),
             Ok(EventDateTime::Date(date))
         );
     }
     #[test]
     fn test_property_to_eventdatetime_2() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("DTSTART"),
-            params: Some(vec![]),
-            value: Some(String::from("19700101T010130")),
-        };
+        let property = icalendar::Property::new("DTSTART", "19700101T010130");
         let date = Local.timestamp_opt(90, 0).unwrap();
         assert_eq!(
-            EventDateTime::try_from(property),
+            EventDateTime::try_from(&property),
             Ok(EventDateTime::DateTime(date))
         );
     }
     #[test]
     fn test_property_to_eventdatetime_err() {
-        let property: ical::property::Property = ical::property::Property {
-            name: String::from("DTSTART"),
-            params: Some(vec![]),
-            value: Some(String::from("19700101010130")),
-        };
-        assert!(EventDateTime::try_from(property).is_err());
+        let property = icalendar::Property::new("DTSTART", "19700101010130");
+        assert!(EventDateTime::try_from(&property).is_err());
     }
     #[test]
     fn test_icalevent_to_event() {
-        let dtstart: ical::property::Property = ical::property::Property {
-            name: String::from("DTSTART"),
-            params: Some(vec![]),
-            value: Some(String::from("19700101T010130")),
-        };
-        let dtend: ical::property::Property = ical::property::Property {
-            name: String::from("DTEND"),
-            params: Some(vec![]),
-            value: Some(String::from("19700101T010130")),
-        };
-        let frequency: ical::property::Property = ical::property::Property {
-            name: String::from("RRULE"),
-            params: None,
-            value: Some(String::from("FREQ=YEARLY")),
-        };
-        let summary: ical::property::Property = ical::property::Property {
-            name: String::from("SUMMARY"),
-            params: None,
-            value: Some(String::from("Some summary")),
-        };
-        let icalevent: IcalEvent = IcalEvent {
-            alarms: vec![],
-            properties: vec![dtstart, dtend, frequency, summary],
-        };
-        assert!(Event::try_from(icalevent).is_ok());
+        let mut icalevent = IcalendarEvent::default();
+        icalevent.add_property("DTSTART", "19700101T010130");
+        assert!(Event::try_from(&icalevent).is_ok());
     }
     #[test]
     fn test_icalevent_to_event_err() {
-        let dtstart: ical::property::Property = ical::property::Property {
-            name: String::from("DTSTART"),
-            params: Some(vec![]),
-            value: Some(String::from("19700101010130")),
-        };
-        let icalevent: IcalEvent = IcalEvent {
-            alarms: vec![],
-            properties: vec![dtstart],
-        };
-        assert!(Event::try_from(icalevent).is_err());
+        let mut icalevent = IcalendarEvent::default();
+        icalevent.add_property("DTSTART", "19700101010130");
+        assert!(Event::try_from(&icalevent).is_err());
     }
     #[test]
     fn test_read_from_ics_file() {

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -5,7 +5,6 @@
 mod ics;
 pub use ics::ReadFromIcsFile;
 
-use crate::utils::ChronoDate;
 use chrono::prelude::*;
 use rrule::{RRuleSet, Tz};
 use std::fmt;
@@ -16,7 +15,7 @@ pub enum EventDateTime {
         date_time: chrono::NaiveDateTime,
         offset: Option<chrono::offset::FixedOffset>,
     },
-    Date(ChronoDate),
+    Date(chrono::NaiveDate),
 }
 
 impl EventDateTime {
@@ -50,11 +49,15 @@ impl Default for Event {
 }
 
 impl Event {
-    pub fn is_day(&self, date: &ChronoDate) -> bool {
+    pub fn is_day(&self, date: &chrono::NaiveDate) -> bool {
         self.in_range(*date, *date)
     }
 
-    pub fn in_range(&self, daterangebegin: ChronoDate, daterangeend: ChronoDate) -> bool {
+    pub fn in_range(
+        &self,
+        daterangebegin: chrono::NaiveDate,
+        daterangeend: chrono::NaiveDate,
+    ) -> bool {
         let timezone: Tz = Local::now().timezone().into();
         let before = timezone
             .with_ymd_and_hms(

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -31,7 +31,7 @@ pub enum EventDateTime {
 #[derive(Debug, Clone)]
 pub struct Event {
     pub start: EventDateTime,
-    pub end: Option<EventDateTime>,
+    pub end: EventDateTime,
     pub frequency: EventFrequency,
     pub summary: String,
 }
@@ -42,7 +42,7 @@ impl Default for Event {
     fn default() -> Event {
         Event {
             start: EventDateTime::Date(NaiveDate::default()),
-            end: None,
+            end: EventDateTime::Date(NaiveDate::default()),
             frequency: EventFrequency::None,
             summary: String::from("Default Event"),
         }
@@ -94,20 +94,17 @@ impl Event {
 
     fn get_end_date(&self) -> ChronoDate {
         match self.end {
-            Some(x) => match x {
-                EventDateTime::DateTime { date_time, .. } => date_time.date(),
-                EventDateTime::Date(y) => match self.start {
-                    EventDateTime::Date(z) => {
-                        if z + Days::new(1) == y {
-                            z
-                        } else {
-                            y
-                        }
+            EventDateTime::DateTime { date_time, .. } => date_time.date(),
+            EventDateTime::Date(y) => match self.start {
+                EventDateTime::Date(z) => {
+                    if z + Days::new(1) == y {
+                        z
+                    } else {
+                        y
                     }
-                    _ => y,
-                },
+                }
+                _ => y,
             },
-            None => self.get_start_date(),
         }
     }
 }
@@ -155,7 +152,7 @@ mod tests {
         let date = NaiveDate::default();
         let event = Event {
             frequency: EventFrequency::Yearly,
-            end: Some(EventDateTime::Date(date)),
+            end: EventDateTime::Date(date),
             ..Default::default()
         };
         assert!(event.is_day(&date));
@@ -190,7 +187,7 @@ mod tests {
         let date = NaiveDate::default();
         let event = Event {
             start: EventDateTime::Date(date),
-            end: Some(EventDateTime::Date(date)),
+            end: EventDateTime::Date(date),
             ..Default::default()
         };
         assert_eq!(event.get_end_date(), date);
@@ -200,7 +197,7 @@ mod tests {
         let date = NaiveDate::default();
         let event = Event {
             start: EventDateTime::Date(date),
-            end: Some(EventDateTime::Date(date + Days::new(1))),
+            end: EventDateTime::Date(date + Days::new(1)),
             ..Default::default()
         };
         assert_eq!(event.get_end_date(), date);

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-extern crate ical;
-
 mod ics;
 pub use ics::ReadFromIcsFile;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,12 @@ use events::{Events, ReadFromIcsFile};
 use output::agenda::Agenda;
 use output::calendar::Calendar;
 use output::date::Date;
-use utils::{ChronoDate, DateExtensions};
+use utils::DateExtensions;
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
     let mut columns = 1;
-    let mut months: Vec<ChronoDate> = vec![];
+    let mut months: Vec<chrono::NaiveDate> = vec![];
 
     let mut ctx: Context;
     match Context::new() {
@@ -37,8 +37,8 @@ fn main() {
         }
     }
 
-    let mut daterangebegin: ChronoDate = ctx.usersetdate.first_day_of_month();
-    let mut daterangeend: ChronoDate = ctx.usersetdate.last_day_of_month();
+    let mut daterangebegin: chrono::NaiveDate = ctx.usersetdate.first_day_of_month();
+    let mut daterangeend: chrono::NaiveDate = ctx.usersetdate.last_day_of_month();
 
     if ctx.opts.three {
         daterangebegin = (ctx.usersetdate - Duration::weeks(4)).first_day_of_month();

--- a/src/output/agenda.rs
+++ b/src/output/agenda.rs
@@ -20,15 +20,11 @@ impl fmt::Display for Agenda<'_> {
             let eventstuple = &mut self.ctx.eventstuple.clone();
             eventstuple.sort_by(|(aevent, _), (bevent, _)| {
                 aevent
-                    .get_start_date()
+                    .start
+                    .date()
                     .month()
-                    .cmp(&bevent.get_start_date().month())
-                    .then(
-                        aevent
-                            .get_start_date()
-                            .day()
-                            .cmp(&bevent.get_start_date().day()),
-                    )
+                    .cmp(&bevent.start.date().month())
+                    .then(aevent.start.date().day().cmp(&bevent.start.date().day()))
             });
             for (event, style) in eventstuple {
                 ret += format!(

--- a/src/output/calendar.rs
+++ b/src/output/calendar.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use crate::utils::{ChronoDate, DateExtensions, MonthFullWeeksIter};
+use crate::utils::{DateExtensions, MonthFullWeeksIter};
 use crate::Context;
 use crate::Date;
 use chrono::{Duration, NaiveDate};
@@ -10,7 +10,7 @@ use chrono::{Duration, NaiveDate};
 use std::fmt;
 
 pub struct Calendar<'a> {
-    pub dates: Vec<ChronoDate>,
+    pub dates: Vec<chrono::NaiveDate>,
     pub columns: usize,
     pub ctx: &'a Context,
 }
@@ -93,7 +93,7 @@ impl fmt::Display for Calendar<'_> {
 
 impl Calendar<'_> {
     fn weekdays(&self) -> String {
-        let mut week: Vec<ChronoDate> = vec![];
+        let mut week: Vec<chrono::NaiveDate> = vec![];
         let (s, e) = if self.ctx.opts.sunday {
             (3, 9)
         } else {
@@ -172,7 +172,7 @@ mod tests {
         };
         ctx.opts.year = true;
 
-        let mut dates: Vec<ChronoDate> = vec![];
+        let mut dates: Vec<chrono::NaiveDate> = vec![];
         let daterangebegin = ctx.usersetdate.first_day_of_year();
         let daterangeend = ctx.usersetdate.last_day_of_year();
         let mut tmpdate = daterangebegin;

--- a/src/output/date.rs
+++ b/src/output/date.rs
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: MIT
 
 use crate::config::{DateProperty, Style, StyleType};
-use crate::utils::{convertstyle, ChronoDate, DateExtensions};
+use crate::utils::{convertstyle, DateExtensions};
 use crate::Context;
 use chrono::Datelike;
 
 use std::fmt;
 
 pub struct Date<'a> {
-    pub date: ChronoDate,
+    pub date: chrono::NaiveDate,
     pub ctx: &'a Context,
-    pub firstdayofdisplayedmonth: ChronoDate,
+    pub firstdayofdisplayedmonth: chrono::NaiveDate,
 }
 
 impl Date<'_> {

--- a/src/utils/date_extensions.rs
+++ b/src/utils/date_extensions.rs
@@ -122,6 +122,21 @@ impl Iterator for MonthFullWeeksIter {
     }
 }
 
+pub struct DateRange(pub NaiveDate, pub NaiveDate);
+
+impl Iterator for DateRange {
+    type Item = NaiveDate;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0 < self.1 {
+            self.0 += Duration::days(1);
+            Some(self.0)
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,8 +4,6 @@
 
 mod date_extensions;
 mod helpers;
-mod types;
 
 pub use date_extensions::{DateExtensions, DateRange, MonthFullWeeksIter};
 pub use helpers::convertstyle;
-pub use types::ChronoDate;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,6 @@ mod date_extensions;
 mod helpers;
 mod types;
 
-pub use date_extensions::{DateExtensions, MonthFullWeeksIter};
+pub use date_extensions::{DateExtensions, DateRange, MonthFullWeeksIter};
 pub use helpers::convertstyle;
 pub use types::{ChronoDate, ChronoDateTime};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,4 +8,4 @@ mod types;
 
 pub use date_extensions::{DateExtensions, DateRange, MonthFullWeeksIter};
 pub use helpers::convertstyle;
-pub use types::{ChronoDate, ChronoDateTime};
+pub use types::ChronoDate;

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2021-2023 Birger Schacht <birger@rantanplan.org>
-//
-// SPDX-License-Identifier: MIT
-
-pub type ChronoDate = chrono::NaiveDate;

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -2,7 +2,4 @@
 //
 // SPDX-License-Identifier: MIT
 
-use chrono::prelude::*;
-
 pub type ChronoDate = chrono::NaiveDate;
-pub type ChronoDateTime = chrono::DateTime<Local>;


### PR DESCRIPTION
- feat: implement calendar parsing using icalendar
- refactor: drop ical dependency
- tests: update tests for icalendar implementation
- refactor: use get_summary() of icalendar::Event
- feat: implement DateRange
- refactor(events): reimplement EventDateTime::DateTime
- refactor(events): add conversion DatePerhapsTime into EventDateTime
- refactor(events): replace optional end date with fixed one
- refactor: implement EventDateTime::date() and use it
- feat: use rrule instead of parsing RRULE manually
