### PR TITLE
fix(deps): bump icalendar version to 0.17.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "icalendar"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25bc68d1c3113be52919708c870cabe55ba0646b9dade87913fe565aa956a3b"
+checksum = "cc3b69b799a03e059f6dc984c25a8bf847d8ca4cbddb079c39ede7b3d24854c3"
 dependencies = [
  "chrono",
  "iso8601",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ toml = "0.9.*"
 serde = { version = "1.0", features = ["derive"] }
 xdg = "3.0.0"
 anstyle = "1.0.11"
-icalendar = "0.17"
+icalendar = "0.17.6"
 rrule = { version = "0.14.0", features = ["serde"]}
 minijinja = { version = "2.12.0", features = ["loader", "custom_syntax"] }
 minijinja-contrib = {version="2.8.0", features = ["datetime"] }


### PR DESCRIPTION
This makes parsing of dates more lenient

Closes: #182
