### PR TITLE
Replace xdg with directories crate to enable more platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +100,7 @@ dependencies = [
  "anstyle",
  "chrono",
  "clap",
+ "directories",
  "icalendar",
  "minijinja",
  "minijinja-contrib",
@@ -101,7 +108,6 @@ dependencies = [
  "rrule",
  "serde",
  "toml",
- "xdg",
 ]
 
 [[package]]
@@ -236,6 +242,27 @@ checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -395,6 +422,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +579,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -949,6 +1003,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,9 +1130,3 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-
-[[package]]
-name = "xdg"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 clap = { version = "4.5.49", features = ["derive", "cargo"] }
 toml = "0.9.*"
 serde = { version = "1.0", features = ["derive"] }
-xdg = "3.0.0"
+directories = "6.0.0"
 anstyle = "1.0.11"
 icalendar = "0.17.6"
 rrule = { version = "0.14.0", features = ["serde"]}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,6 @@ mod theme;
 pub use theme::StyleName::*;
 pub use theme::{DateProperty, Style, StyleName, StyleType, Theme};
 
-extern crate xdg;
 use clap::crate_name;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -24,12 +23,15 @@ pub struct Config {
 impl Config {
     #[cfg(not(tarpaulin_include))]
     pub fn read() -> Config {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix(crate_name!());
-        if let Some(config_path) = xdg_dirs.find_config_file("config.toml") {
-            let config_content = fs::read_to_string(config_path).unwrap_or_default();
-            match toml::from_str(&config_content) {
-                Ok(config) => return config,
-                Err(e) => eprintln!("Could not parse config file: {}", e),
+        if let Some(config_path) = directories::ProjectDirs::from("org", "birger", crate_name!()) {
+            let config_path = config_path.config_dir().as_os_str();
+            let config_file = PathBuf::from(config_path).join("config.toml");
+            if config_file.exists() {
+                let config_content = fs::read_to_string(config_file).unwrap_or_default();
+                match toml::from_str(&config_content) {
+                    Ok(config) => return config,
+                    Err(e) => eprintln!("Could not parse config file: {}", e),
+                }
             }
         } else {
             //for now disabled, should only be shown with some kind of --debug flag

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ mod utils;
 extern crate clap;
 extern crate serde;
 extern crate toml;
-extern crate xdg;
 use std::process;
 
 use context::Context;
@@ -77,7 +76,7 @@ fn main() {
     minijinja_contrib::add_to_environment(&mut env);
 
     let date_styler = objects::DateStyler::new(event_instances.clone(), ctx.usersetdate, ctx.specified_date, ctx.theme.clone(), ctx.styletype);
-    let template_context = context! { 
+    let template_context = context! {
         cli => ctx.opts,
         columns => ctx.columns,
         dates_per_month => dates_per_month,


### PR DESCRIPTION
The `xdg` crate works only on Linux alike systems. The `directories` crate support Linux, Mac, and Win.

This PR enables building and working `carl` on Windows.

Closes: #188 