### PR TITLE
style: drop `extern crate` declarations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,6 @@ mod events;
 mod template;
 mod utils;
 
-extern crate clap;
-extern crate serde;
-extern crate toml;
 use std::process;
 
 use context::Context;


### PR DESCRIPTION
The `extern crate` declaration is not longer needed since Rust 2018:
https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html
